### PR TITLE
Make pact tests work in dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea/**
-
+**/*dylib
 /quarkus-pact-parent.iml

--- a/quarkus-pact-provider/README.md
+++ b/quarkus-pact-provider/README.md
@@ -2,24 +2,10 @@
 
 [![Version](https://img.shields.io/maven-central/v/io.quarkiverse/quarkus-pact-provider?logo=apache-maven&style=flat-square)](https://search.maven.org/artifact/io.quarkiverse/quarkus-pact-provider)
 
-## Welcome to Quarkiverse!
+# Running the integration test project
 
-Congratulations and thank you for creating a new Quarkus extension project in Quarkiverse!
+Most problems are complex classloading ones, which are only exposed by running the integration tests.
 
-Feel free to replace this content with the proper description of your new project and necessary instructions how to use and contribute to it.
-
-You can find the basic info, Quarkiverse policies and conventions in [the Quarkiverse wiki](https://github.com/quarkiverse/quarkiverse/wiki).
-
-In case you are creating a Quarkus extension project for the first time, please follow [Building My First Extension](https://quarkus.io/guides/building-my-first-extension) guide.
-
-Other useful articles related to Quarkus extension development can be found under the [Writing Extensions](https://quarkus.io/guides/#writing-extensions) guide category on the [Quarkus.io](https://quarkus.io) website.
-
-Thanks again, good luck and have fun!
-
-## Documentation
-
-The documentation for this extension should be maintained as part of this repository and it is stored in the `docs/` directory.
-
-The layout should follow the [Antora's Standard File and Directory Set](https://docs.antora.org/antora/2.3/standard-directories/).
-
-Once the docs are ready to be published, please open a PR including this repository in the [Quarkiverse Docs Antora playbook](https://github.com/quarkiverse/quarkiverse-docs/blob/main/antora-playbook.yml#L7). See an example [here](https://github.com/quarkiverse/quarkiverse-docs/pull/1).
+Running the integration test application without running the tests can sometimes be useful for debugging.
+See [the test project `README.md`](integration-tests/src/test/resources-filtered/projects/happy-farm/README.md) for
+instructions.

--- a/quarkus-pact-provider/deployment/pom.xml
+++ b/quarkus-pact-provider/deployment/pom.xml
@@ -26,6 +26,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-kotlin-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jsonb</artifactId>
       <scope>test</scope>
     </dependency>

--- a/quarkus-pact-provider/integration-tests/pom.xml
+++ b/quarkus-pact-provider/integration-tests/pom.xml
@@ -45,6 +45,9 @@
       <testResource>
         <directory>src/test/resources-filtered</directory>
         <filtering>true</filtering>
+        <excludes>
+          <exclude>**/target/**</exclude> <!-- Target folders sometimes creep in when manually executing locally-->
+        </excludes>
       </testResource>
       <testResource>
         <directory>src/test/resources</directory>

--- a/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -1,20 +1,18 @@
 package io.quarkiverse.pact.it;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import io.quarkus.maven.it.RunAndCheckMojoTestBase;
+import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
+import io.quarkus.test.devmode.util.DevModeTestUtils;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.io.FileNotFoundException;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.maven.shared.invoker.MavenInvocationException;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-
-import io.quarkus.maven.it.RunAndCheckMojoTestBase;
-import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
-import io.quarkus.test.devmode.util.DevModeTestUtils;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Because Pact uses Kotlin under the covers, we see different behaviour
@@ -47,7 +45,6 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
         assertThat(json).containsIgnoringCase("colour");
     }
 
-    @Disabled // See https://github.com/quarkiverse/quarkus-pact/issues/11
     @Test
     public void testThatTheTestsPassed() throws MavenInvocationException, FileNotFoundException {
         //we also check continuous testing
@@ -62,7 +59,9 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
 
         ContinuousTestingMavenTestUtils testingTestUtils = new ContinuousTestingMavenTestUtils();
         ContinuousTestingMavenTestUtils.TestStatus results = testingTestUtils.waitForNextCompletion();
-        Assertions.assertEquals(1, results.getTestsPassed());
+        Assertions.assertEquals(2, results.getTestsPassed());
+        Assertions.assertEquals(0, results.getTestsFailed());
+
     }
 
 }

--- a/quarkus-pact-provider/integration-tests/src/test/resources-filtered/projects/happy-farm/README.md
+++ b/quarkus-pact-provider/integration-tests/src/test/resources-filtered/projects/happy-farm/README.md
@@ -1,5 +1,6 @@
-You can run this sample project independently to debug issues. You will need to be in the filtered output directory, not
-the source directory (usually `target/test-classes/projects/happy-farm-processed`)
+You can run this sample project independently to debug issues. This project is a filtered resource, so you will need to
+run from the filtered output directory, not the source directory (
+usually `target/test-classes/projects/happy-farm-processed`).
 
 Use
 
@@ -12,3 +13,9 @@ or, for continuous testing and dev mode,
 ```bash
 mvn quarkus:dev
 ```
+
+If you do want to run in the source directory, you will need to edit `pom.xml` to add temporary versions for these
+properties:
+
+- `quarkus.version`
+- `project.version`

--- a/quarkus-pact-provider/integration-tests/src/test/resources-filtered/projects/happy-farm/pom.xml
+++ b/quarkus-pact-provider/integration-tests/src/test/resources-filtered/projects/happy-farm/pom.xml
@@ -4,7 +4,8 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>test-application</groupId>
   <artifactId>happy-farm</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>${project.version}</version>
+
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>
@@ -13,7 +14,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.11.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
   <dependencyManagement>
@@ -21,7 +21,7 @@
       <dependency>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>
-        <version>${quarkus.platform.version}</version>
+        <version>${quarkus.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -41,8 +41,8 @@
     <dependency>
       <groupId>io.quarkiverse.pact</groupId>
       <artifactId>quarkus-pact-provider</artifactId>
-      <version>999-SNAPSHOT</version>
-      <scope>test</scope>
+      <version>${project.version}</version>
+      <!-- <scope>test</scope>--> <!-- See https://github.com/quarkiverse/quarkus-pact/issues/28; for dev mode tests, the scope cannot be test -->
     </dependency>
 
   </dependencies>
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.platform.version}</version>
+        <version>${quarkus.version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>

--- a/quarkus-pact-provider/integration-tests/src/test/resources-filtered/projects/happy-farm/src/test/java/io/quarkiverse/pact/devmodetest/farm/DummyAlpacaTest.java
+++ b/quarkus-pact-provider/integration-tests/src/test/resources-filtered/projects/happy-farm/src/test/java/io/quarkiverse/pact/devmodetest/farm/DummyAlpacaTest.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.pact.devmodetest.farm;
+
+import io.quarkiverse.pact.testapp.IntegrationDevModeAlpaca;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * This test doesn't actually do anything useful, but if it's present when running dev mode tests,
+ * we get more useful output out from failures in the templated contract test we care about.
+ * Otherwise, classloading failures can be silent.
+ */
+public class DummyAlpacaTest {
+    @Test
+    public void visitShouldReturnSomething() {
+        IntegrationDevModeAlpaca stubby = new IntegrationDevModeAlpaca();
+        assertNotNull(stubby);
+    }
+
+}

--- a/quarkus-pact-provider/integration-tests/src/test/resources-filtered/projects/happy-farm/src/test/java/io/quarkiverse/pact/devmodetest/farm/FarmContractTest.java
+++ b/quarkus-pact-provider/integration-tests/src/test/resources-filtered/projects/happy-farm/src/test/java/io/quarkiverse/pact/devmodetest/farm/FarmContractTest.java
@@ -1,9 +1,4 @@
-package io.quarkiverse.pact.devmodetest.farm.house;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.ExtendWith;
+package io.quarkiverse.pact.devmodetest.farm;
 
 import au.com.dius.pact.provider.junit5.HttpTestTarget;
 import au.com.dius.pact.provider.junit5.PactVerificationContext;
@@ -11,6 +6,10 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.Provider;
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
 import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @Provider("Farm")
 @PactFolder("pacts")
@@ -30,5 +29,4 @@ public class FarmContractTest {
     void pactVerificationTestTemplate(PactVerificationContext context) {
         context.verifyInteraction();
     }
-
 }

--- a/quarkus-pact-provider/runtime/pom.xml
+++ b/quarkus-pact-provider/runtime/pom.xml
@@ -15,6 +15,10 @@
       <artifactId>quarkus-arc</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-kotlin</artifactId>
+    </dependency>
+    <dependency>
       <groupId>au.com.dius.pact.provider</groupId>
       <artifactId>junit5</artifactId>
       <version>${pact.version}</version>
@@ -26,6 +30,23 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-extension-maven-plugin</artifactId>
         <version>${quarkus.version}</version>
+        <configuration>
+          <parentFirstArtifacts>
+            <parentFirstArtifact>io.github.microutils:kotlin-logging-jvm</parentFirstArtifact>
+            <parentFirstArtifact>com.michael-bull.kotlin-result:kotlin-result-jvm</parentFirstArtifact>
+            <parentFirstArtifact>io.ktor:ktor-http-jvm</parentFirstArtifact>
+            <!-- Here we go back into Java code from the Kotlin code -->
+            <parentFirstArtifact>org.apache.tika:tika-core</parentFirstArtifact>
+            <parentFirstArtifact>org.apache.httpcomponents.core5:httpcore5</parentFirstArtifact>
+            <parentFirstArtifact>org.apache.httpcomponents.client5:httpclient5</parentFirstArtifact>
+            <parentFirstArtifact>com.github.ajalt:mordant</parentFirstArtifact>
+            <parentFirstArtifact>au.com.dius.pact.core:matchers</parentFirstArtifact>
+            <parentFirstArtifact>io.pact.plugin.driver:core</parentFirstArtifact>
+            <parentFirstArtifact>org.apache.commons:commons-collections4</parentFirstArtifact>
+            <parentFirstArtifact>com.github.zafarkhaja:java-semver</parentFirstArtifact>
+            <parentFirstArtifact>io.github.java-diff-utils:java-diff-utils</parentFirstArtifact>
+          </parentFirstArtifacts>
+        </configuration>
         <executions>
           <execution>
             <phase>compile</phase>

--- a/quarkus-pact-provider/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/quarkus-pact-provider/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,9 +1,9 @@
 name: Pact Provider
-#description: Do something useful.
+description: Support for running a pact provider in Quarkus, including in Quarkus dev mode.
 metadata:
-#  keywords:
-#    - pact-provider
-#  guide: https://quarkiverse.github.io/quarkiverse-docs/pact-provider/dev/
-#  categories:
-#    - "miscellaneous"
-#  status: "preview"
+  keywords:
+    - contract-testing, pact
+  #  guide: https://quarkiverse.github.io/quarkiverse-docs/pact-provider/dev/
+  categories:
+    - "testing"
+  status: "experimental"


### PR DESCRIPTION
Resolves #11 

This PR does the following:

- Enable the integration tests, which had been failing
- Use filtered versions rather than hardcoded versions in the integration project pom
- Add a dummy test to help problem diagnosis in the integration tests
- Make the integration tests work, by … 
- Setting the scope of the extension dependency to not-test; this isn’t great, but may be hard to fix. 
- Making pact work in dev mode


The changes to make pact work in dev mode are 

- Add the quarkus kotlin extension as a dependency to the extension
- Set a bunch of libraries used by pact to be parent first, to work around `NoClassDefFoundError` issues. I’m a bit concerned about the implications of this change, since parent-firstness tends to spread virally through a codebase via transitive dependencies. However, I also don’t see an alternative. 

