### PR TITLE
Release 0.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "0"
-  next-version: "999-SNAPSHOT"
+  current-version: "0.1"
+  next-version: "0.2-SNAPSHOT"
 

--- a/quarkus-pact-provider/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/quarkus-pact-provider/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:project-version: 0
+:project-version: 0.1
 
 :examples-dir: ./../examples/

--- a/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -1,18 +1,19 @@
 package io.quarkiverse.pact.it;
 
-import io.quarkus.maven.it.RunAndCheckMojoTestBase;
-import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
-import io.quarkus.test.devmode.util.DevModeTestUtils;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.FileNotFoundException;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-import java.io.FileNotFoundException;
-import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import io.quarkus.maven.it.RunAndCheckMojoTestBase;
+import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
+import io.quarkus.test.devmode.util.DevModeTestUtils;
 
 /**
  * Because Pact uses Kotlin under the covers, we see different behaviour


### PR DESCRIPTION
- Enables provider tests to run in dev mode 
- The extension dependency must *not* have `test` scope in the pom.xml when using dev mode