### PR TITLE
Revert "Adjust release.yml for multi-extension scenario"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           git checkout -b release
           mvn -B release:prepare -Prelease -DpreparationGoals="clean install" -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}
-          if ! git diff --quiet */docs/modules/ROOT/pages/includes/attributes.adoc; then
-            git add */docs/modules/ROOT/pages/includes/attributes.adoc
+          if ! git diff --quiet docs/modules/ROOT/pages/includes/attributes.adoc; then
+            git add docs/modules/ROOT/pages/includes/attributes.adoc
             git commit -m "Update stable version for documentation"
           fi
           git checkout ${{github.base_ref}}
@@ -63,8 +63,8 @@ jobs:
         run: |
           git checkout ${{steps.metadata.outputs.current-version}}
           mvn -B clean install -DskipTests -DskipITs
-          if ! git diff --quiet */docs/modules/ROOT/pages/includes/attributes.adoc; then
-            git add */docs/modules/ROOT/pages/includes/attributes.adoc
+          if ! git diff --quiet docs/modules/ROOT/pages/includes/attributes.adoc; then
+            git add docs/modules/ROOT/pages/includes/attributes.adoc
             git commit -m "Update stable version for documentation"
             # Move the tag after inclusion of documentation adjustments
             git tag -f ${{steps.metadata.outputs.current-version}}


### PR DESCRIPTION
It may be responsible for the failure of the recent 0.2 release: https://github.com/quarkiverse/quarkus-pact/actions/runs/3885280542