### PR TITLE
Troublesome import ordering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           git checkout -b release
           mvn -B release:prepare -Prelease -DpreparationGoals="clean install" -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}
-          if ! git diff --quiet */docs/modules/ROOT/pages/includes/attributes.adoc; then
-            git add */docs/modules/ROOT/pages/includes/attributes.adoc
+          if ! git diff --quiet docs/modules/ROOT/pages/includes/attributes.adoc; then
+            git add docs/modules/ROOT/pages/includes/attributes.adoc
             git commit -m "Update stable version for documentation"
           fi
           git checkout ${{github.base_ref}}
@@ -63,8 +63,8 @@ jobs:
         run: |
           git checkout ${{steps.metadata.outputs.current-version}}
           mvn -B clean install -DskipTests -DskipITs
-          if ! git diff --quiet */docs/modules/ROOT/pages/includes/attributes.adoc; then
-            git add */docs/modules/ROOT/pages/includes/attributes.adoc
+          if ! git diff --quiet docs/modules/ROOT/pages/includes/attributes.adoc; then
+            git add docs/modules/ROOT/pages/includes/attributes.adoc
             git commit -m "Update stable version for documentation"
             # Move the tag after inclusion of documentation adjustments
             git tag -f ${{steps.metadata.outputs.current-version}}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/target/*
 **/*dylib
 /quarkus-pact-parent.iml
+/docs/quarkus-pact-docs.iml
+*.iml

--- a/docs/quarkus-pact-docs.iml
+++ b/docs/quarkus-pact-docs.iml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="Quarkus Tools">
-    <option name="hash" value="1069400310" />
-    <option name="version" value="1" />
-  </component>
-</module>

--- a/quarkus-pact-consumer/integration-tests/src/test/java/io/quarkiverse/pact/it/NormalModeFarmConsumerIT.java
+++ b/quarkus-pact-consumer/integration-tests/src/test/java/io/quarkiverse/pact/it/NormalModeFarmConsumerIT.java
@@ -1,14 +1,7 @@
 package io.quarkiverse.pact.it;
 
-import au.com.dius.pact.consumer.MockServer;
-import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
-import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
-import au.com.dius.pact.consumer.junit5.PactTestFor;
-import au.com.dius.pact.core.model.V4Pact;
-import au.com.dius.pact.core.model.annotations.Pact;
-import au.com.dius.pact.core.model.annotations.PactDirectory;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.net.URI;
@@ -19,8 +12,16 @@ import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.V4Pact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.annotations.PactDirectory;
 
 @ExtendWith(PactConsumerTestExt.class)
 @PactTestFor(providerName = "farm", port = "8086")


### PR DESCRIPTION
This was causing a release failure because the build would fix the import ordering. It was hard to spot because locally the IDE instantly undid the build changes.