### PR TITLE
Add tests for what happens with `quarkus:test`

### DIFF
--- a/quarkus-pact-consumer/integration-tests/src/test/java/io/quarkiverse/pact/it/TestModeContractTestIT.java
+++ b/quarkus-pact-consumer/integration-tests/src/test/java/io/quarkiverse/pact/it/TestModeContractTestIT.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.pact.it;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -11,13 +10,13 @@ import java.nio.file.Paths;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.maven.it.RunAndCheckMojoTestBase;
 import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
-import io.quarkus.test.devmode.util.DevModeTestUtils;
+import io.quarkus.maven.it.continuoustesting.TestModeContinuousTestingMavenTestUtils;
+import io.quarkus.runtime.LaunchMode;
 
 /**
  * Because Pact uses Kotlin under the covers, we see different behaviour
@@ -29,29 +28,43 @@ import io.quarkus.test.devmode.util.DevModeTestUtils;
  * mvn install -Dit.test=DevMojoIT#methodName
  */
 @DisabledIfSystemProperty(named = "quarkus.test.native", matches = "true")
-@Disabled
-public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
+public class TestModeContractTestIT extends RunAndCheckMojoTestBase {
 
-    protected void runAndCheck(boolean performCompile, String... options)
-            throws MavenInvocationException, FileNotFoundException {
-        run(performCompile, options);
+    @Override
+    protected LaunchMode getDefaultLaunchMode() {
+        return LaunchMode.TEST;
+    }
 
-        String resp = DevModeTestUtils.getHttpResponse();
+    @Override
+    public void shutdownTheApp() {
+        if (running != null) {
+            running.stop();
+        }
 
-        assertThat(resp).containsIgnoringCase("ready").containsIgnoringCase("application")
-                .containsIgnoringCase("1.0-SNAPSHOT");
+        // There's no http server, so there's nothing to check to make sure we're stopped, except by the maven invoker itself, or the logs
+    }
 
-        // There's no json endpoints, so nothing else to check
+    /**
+     * This is actually more like runAndDoNotCheck, because
+     * we can't really check anything via a HTTP get, because this is a test mode application
+     */
+    @Override
+    protected void runAndCheck(boolean performCompile, LaunchMode mode, String... options)
+            throws FileNotFoundException, MavenInvocationException {
+        run(performCompile, mode, options);
+
+        // We don't need to try and pause, because the continuous testing utils will wait for tests to finish
+
     }
 
     @Test
     public void testThatTheTestsPassed() throws MavenInvocationException, IOException {
         //we also check continuous testing
-        String executionDir = "projects/happy-knitter-processed";
+        String executionDir = "projects/happy-knitter-processed-testmode";
         testDir = initProject("projects/happy-knitter", executionDir);
         runAndCheck();
 
-        ContinuousTestingMavenTestUtils testingTestUtils = new ContinuousTestingMavenTestUtils();
+        ContinuousTestingMavenTestUtils testingTestUtils = new TestModeContinuousTestingMavenTestUtils(running);
         ContinuousTestingMavenTestUtils.TestStatus results = testingTestUtils.waitForNextCompletion();
         // This is a bit brittle when we add tests, but failures are often so catastrophic they're not even reported as failures,
         // so we need to check the pass count explicitly
@@ -61,6 +74,8 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
         // Now confirm a pact file got written by the pact consumer
         File targetFolder = new File("target/test-classes/" + executionDir + "/target");
         assertTrue(targetFolder.exists(), targetFolder.getAbsolutePath() + " should exist (is this a test code error?)");
+
+        // This is hardcoded in the pact file, so we have to share a name with the other test, but the parent folder is different
         File pactFolder = new File(targetFolder, "devmode-pacts");
         assertTrue(pactFolder.exists(), pactFolder.getAbsolutePath() + " should exist");
         File pactFile = new File(pactFolder, "knitter-farm.json");

--- a/quarkus-pact-consumer/integration-tests/src/test/resources-filtered/projects/happy-knitter/pom.xml
+++ b/quarkus-pact-consumer/integration-tests/src/test/resources-filtered/projects/happy-knitter/pom.xml
@@ -46,7 +46,7 @@
       <groupId>io.quarkiverse.pact</groupId>
       <artifactId>quarkus-pact-consumer</artifactId>
       <version>${project.version}</version>
-      <!-- <scope>test</scope>--> <!-- See https://github.com/quarkiverse/quarkus-pact/issues/28; for dev mode tests, the scope cannot be test -->
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -25,6 +26,8 @@ import io.quarkus.test.devmode.util.DevModeTestUtils;
  * mvn install -Dit.test=DevMojoIT#methodName
  */
 @DisabledIfSystemProperty(named = "quarkus.test.native", matches = "true")
+// See https://github.com/quarkiverse/quarkus-pact/issues/28; for dev mode tests, the extension scope cannot be test
+@Disabled
 public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
 
     protected void runAndCheck(String... options) throws MavenInvocationException, FileNotFoundException {

--- a/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/TtestModeContractTestIT.java
+++ b/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/TtestModeContractTestIT.java
@@ -1,0 +1,82 @@
+package io.quarkiverse.pact.it;
+
+import java.io.FileNotFoundException;
+
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import io.quarkus.maven.it.RunAndCheckMojoTestBase;
+import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
+import io.quarkus.maven.it.continuoustesting.TestModeContinuousTestingMavenTestUtils;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * Because Pact uses Kotlin under the covers, we see different behaviour
+ * in continuous testing and normal maven modes. This test exercises the continuous
+ * testing with Pact.
+ * We also see different behaviour in test mode and dev mode,
+ * so we need to explicitly try test mode.
+ * <p>
+ * NOTE to anyone diagnosing failures in this test, to run a single method use:
+ * <p>
+ * mvn install -Dit.test=DevMojoIT#methodName
+ *
+ * Why does this class have a strange name? Good question.
+ * There's some cross-talk between the tests, so that if this test runs, and takes more than a few milliseconds,
+ * the NormalModeContractIT test fails. It fails with a message that the resources project's classes
+ * can't be found ... even though the NormalModeContractIT test doesn't even use them.
+ *
+ * Changing this class so that the name doesn't start with Test works around the issue.
+ */
+@DisabledIfSystemProperty(named = "quarkus.test.native", matches = "true")
+public class TtestModeContractTestIT extends RunAndCheckMojoTestBase {
+
+    @Override
+    protected LaunchMode getDefaultLaunchMode() {
+        return LaunchMode.TEST;
+    }
+
+    @Override
+    public void shutdownTheApp() {
+        if (running != null) {
+            running.stop();
+        }
+
+        // There's no http server, so there's nothing to check to make sure we're stopped, except by the maven invoker itself, or the logs
+    }
+
+    /**
+     * This is actually more like runAndDoNotCheck, because
+     * we can't really check anything via a HTTP get, because this is a test mode application
+     */
+    @Override
+    protected void runAndCheck(boolean performCompile, LaunchMode mode, String... options)
+            throws FileNotFoundException, MavenInvocationException {
+        run(performCompile, mode, options);
+
+        // We don't need to try and pause, because the continuous testing utils will wait for tests to finish
+
+    }
+
+    protected void runAndCheck(String... options) throws MavenInvocationException, FileNotFoundException {
+        // To avoid clashes with other tests, we use a non-default port
+        runAndCheck(true, "-Dquarkus.http.test-port=8088");
+    }
+
+    @Test
+    public void testThatTheTestsPassed() throws MavenInvocationException, FileNotFoundException {
+
+        testDir = initProject("projects/happy-farm", "projects/happy-farm-testmode-processed");
+        runAndCheck();
+
+        TestModeContinuousTestingMavenTestUtils testingTestUtils = new TestModeContinuousTestingMavenTestUtils(running);
+
+        ContinuousTestingMavenTestUtils.TestStatus results = testingTestUtils.waitForNextCompletion();
+        Assertions.assertEquals(2, results.getTestsPassed());
+        Assertions.assertEquals(0, results.getTestsFailed());
+
+    }
+
+}

--- a/quarkus-pact-provider/integration-tests/src/test/resources-filtered/projects/happy-farm/pom.xml
+++ b/quarkus-pact-provider/integration-tests/src/test/resources-filtered/projects/happy-farm/pom.xml
@@ -42,7 +42,7 @@
       <groupId>io.quarkiverse.pact</groupId>
       <artifactId>quarkus-pact-provider</artifactId>
       <version>${project.version}</version>
-      <!-- <scope>test</scope>--> <!-- See https://github.com/quarkiverse/quarkus-pact/issues/28; for dev mode tests, the scope cannot be test -->
+      <scope>test</scope>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Related to #28. 

Since `quarkus:test` and `quarkus:dev` can behave differently, I've added some new tests for running this way. Test mode now works properly with `test` scope, but dev mode does not yet. 

I wasn't sure which workaround to leave in the codebase, but in the end I switched to `test` scope and therefore disabled the dev mode tests. 

This change requires https://github.com/quarkusio/quarkus/pull/30281 and https://github.com/quarkusio/quarkus/pull/30238, so it can't be merged until Quarkus 2.16.