### PR TITLE
Correct bad link in ecosystem ci setup.

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -2,7 +2,7 @@ name: "Quarkus ecosystem CI"
 on:
   workflow_dispatch:
   watch:
-    types: [started]
+    types: [ started ]
 
   # For this CI to work, ECOSYSTEM_CI_TOKEN needs to contain a GitHub with rights to close the Quarkus issue that the user/bot has opened,
   # while 'ECOSYSTEM_CI_REPO_PATH' needs to be set to the corresponding path in the 'quarkusio/quarkus-ecosystem-ci' repository
@@ -16,7 +16,7 @@ env:
   # Repo specific setting #
   #########################
 
-  ECOSYSTEM_CI_REPO_PATH: quarkiverse-pact-provider
+  ECOSYSTEM_CI_REPO_PATH: quarkiverse-pact
 
 jobs:
   build:


### PR DESCRIPTION
I don't think the CI for this PR will show much, since it's a different build run on an automated schedule, but we can confirm it doesn't break things, at least. 