### PR TITLE
Fix typo in class name

### DIFF
--- a/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/TheTestModeContractTestIT.java
+++ b/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/TheTestModeContractTestIT.java
@@ -31,7 +31,7 @@ import io.quarkus.runtime.LaunchMode;
  * Changing this class so that the name doesn't start with Test works around the issue.
  */
 @DisabledIfSystemProperty(named = "quarkus.test.native", matches = "true")
-public class TtestModeContractTestIT extends RunAndCheckMojoTestBase {
+public class TheTestModeContractTestIT extends RunAndCheckMojoTestBase {
 
     @Override
     protected LaunchMode getDefaultLaunchMode() {


### PR DESCRIPTION
Interestingly, the class name is *not* a typo, it's a workaround for a very subtle bug. If the test name starts with Test, it causes other tests to fail with missing resource issues. However, with the name as `Ttest`, I'm likely to try to fix the name every few weeks, when I forget why the name is the way it is, and don't read the comment. 