### PR TITLE
Fix incorrect name in cross-extension tests, caught only by CI ecosystem

### DIFF
--- a/cross-extension-integration-tests/pom.xml
+++ b/cross-extension-integration-tests/pom.xml
@@ -4,8 +4,8 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.pact</groupId>
-    <artifactId>quarkus-pact-provider-parent</artifactId>
-    <version>0.3-SNAPSHOT</version>
+    <artifactId>quarkus-pact-parent</artifactId>
+    <version>1.1-SNAPSHOT</version>
   </parent>
   <artifactId>cross-extension-integration-tests</artifactId>
   <name>Quarkus Pact - Cross-extension Integration Tests</name>


### PR DESCRIPTION
The ecosystem builds are failing with the following error:

```
2023-03-13T06:15:18.9350281Z [ERROR] [ERROR] Some problems were encountered while processing the POMs:
2023-03-13T06:15:18.9352044Z [WARNING] 'parent.relativePath' of POM io.quarkiverse.pact:cross-extension-integration-tests:0.3-SNAPSHOT (/home/runner/work/quarkus-pact/quarkus-pact/current-repo/cross-extension-integration-tests/pom.xml) points at io.quarkiverse.pact:quarkus-pact-parent instead of io.quarkiverse.pact:quarkus-pact-provider-parent, please verify your project structure @ line 5, column 11
2023-03-13T06:15:18.9354496Z [FATAL] Non-resolvable parent POM for io.quarkiverse.pact:cross-extension-integration-tests:0.3-SNAPSHOT: Could not find artifact io.quarkiverse.pact:quarkus-pact-provider-parent:pom:0.3-SNAPSHOT in snapshots-repo (https://oss.sonatype.org/content/repositories/snapshots) and 'parent.relativePath' points at wrong local POM @ line 5, column 11
2023-03-13T06:15:18.9355703Z [WARNING] 'build.plugins.plugin.version' for io.quarkus:quarkus-maven-plugin is missing. @ line 31, column 15
2023-03-13T06:15:18.9359595Z  @ 
```