### PR TITLE
Release version based on Quarkus 3.0.0.Final

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "1.0.0.Alpha2"
+  current-version: "1.0.0.Final"
   next-version: "1.1-SNAPSHOT"
 


### PR DESCRIPTION
It's useful to have a .Final version in the quarkiverse, rather than the .Alpha2 release which isn't visible to all tooling.