### PR TITLE
Re-enable tests 

### DIFF
--- a/cross-extension-integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/cross-extension-integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -26,8 +25,6 @@ import io.quarkus.test.devmode.util.DevModeTestUtils;
  * mvn install -Dit.test=DevMojoIT#methodName
  */
 @DisabledIfSystemProperty(named = "quarkus.test.native", matches = "true")
-// See https://github.com/quarkiverse/quarkus-pact/issues/28; for dev mode tests, the extension scope cannot be test
-@Disabled
 public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
 
     protected void runAndCheck(String... options) throws MavenInvocationException, FileNotFoundException {

--- a/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -26,8 +25,6 @@ import io.quarkus.test.devmode.util.DevModeTestUtils;
  * mvn install -Dit.test=DevMojoIT#methodName
  */
 @DisabledIfSystemProperty(named = "quarkus.test.native", matches = "true")
-// See https://github.com/quarkiverse/quarkus-pact/issues/28; for dev mode tests, the extension scope cannot be test
-@Disabled
 public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
 
     protected void runAndCheck(String... options) throws MavenInvocationException, FileNotFoundException {


### PR DESCRIPTION
These were fixed by https://github.com/quarkusio/quarkus/pull/30383, but I missed re-enabling the tests. 

With this, I think we can say that #28 is sorted out. Both extensions run with `test` scope with both `quarkus:dev` and `quarkus:test`.