### PR TITLE
Ref #136: Re-add Groovy as parent-first artifact

### DIFF
--- a/quarkus-pact-provider/runtime/pom.xml
+++ b/quarkus-pact-provider/runtime/pom.xml
@@ -31,6 +31,7 @@
         <version>${quarkus.version}</version>
         <configuration>
           <parentFirstArtifacts>
+            <parentFirstArtifact>org.apache.groovy:groovy</parentFirstArtifact>
             <parentFirstArtifact>au.com.dius.pact.provider:junit5</parentFirstArtifact>
             <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk8</parentFirstArtifact>
             <parentFirstArtifact>org.jetbrains.kotlin:kotlin-stdlib-jdk7</parentFirstArtifact>


### PR DESCRIPTION
fixes #136 

## Motivation

With the latest snapshot of Quarkus, the tests fail with `ClassNotFoundException: groovy.lang.Closure` due to https://github.com/quarkusio/quarkus/pull/34447

## Modifications:

* Re-add Groovy as parent-first artifact

## Result

The tests pass again

```
mvn clean install -Dnative
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Quarkus - Pact - Parent 1.1-SNAPSHOT:
[INFO] 
[INFO] Quarkus - Pact - Parent ............................ SUCCESS [  0.991 s]
[INFO] Quarkus Pact Provider - Parent ..................... SUCCESS [  0.021 s]
[INFO] Quarkus Pact Provider - Runtime .................... SUCCESS [  1.560 s]
[INFO] Quarkus Pact Provider - Deployment ................. SUCCESS [ 29.659 s]
[INFO] Quarkus Pact Provider - Integration Tests .......... SUCCESS [02:49 min]
[INFO] Quarkus Pact Consumer - Parent ..................... SUCCESS [  0.029 s]
[INFO] Quarkus Pact Consumer - Runtime .................... SUCCESS [  0.402 s]
[INFO] Quarkus Pact Consumer - Deployment ................. SUCCESS [ 13.054 s]
[INFO] Quarkus Pact Consumer - Integration Tests .......... SUCCESS [03:17 min]
[INFO] Quarkus Pact - Documentation ....................... SUCCESS [  6.526 s]
[INFO] Quarkus Pact - Cross-extension Integration Tests ... SUCCESS [03:01 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10:01 min
[INFO] Finished at: 2023-07-10T15:38:38+02:00
[INFO] ------------------------------------------------------------------------
```
