### PR TITLE
Tidy deprecation warning for `DevModeTestUtils`

### DIFF
--- a/cross-extension-integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/cross-extension-integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.maven.it.RunAndCheckMojoTestBase;
 import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
-import io.quarkus.test.devmode.util.DevModeTestUtils;
 
 /**
  * Because Pact uses Kotlin under the covers, we see different behaviour
@@ -36,12 +35,12 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
             throws MavenInvocationException, FileNotFoundException {
         run(performCompile, options);
 
-        String resp = DevModeTestUtils.getHttpResponse();
+        String resp = devModeClient.getHttpResponse();
 
         assertThat(resp).containsIgnoringCase("ready").containsIgnoringCase("application")
                 .containsIgnoringCase("1.0-SNAPSHOT");
 
-        String json = DevModeTestUtils.getHttpResponse("/alpaca");
+        String json = devModeClient.getHttpResponse("/alpaca");
         //Minimal sense check, the tests do the heavy validation
         assertThat(json).containsIgnoringCase("colour");
     }
@@ -55,7 +54,7 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
                 .atMost(5, TimeUnit.SECONDS)
-                .until(() -> DevModeTestUtils.getHttpResponse("/alpaca").startsWith("{"));
+                .until(() -> devModeClient.getHttpResponse("/alpaca").startsWith("{"));
 
         ContinuousTestingMavenTestUtils testingTestUtils = new ContinuousTestingMavenTestUtils();
         ContinuousTestingMavenTestUtils.TestStatus results = testingTestUtils.waitForNextCompletion();

--- a/quarkus-pact-consumer/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/quarkus-pact-consumer/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.maven.it.RunAndCheckMojoTestBase;
 import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
-import io.quarkus.test.devmode.util.DevModeTestUtils;
 
 /**
  * Because Pact uses Kotlin under the covers, we see different behaviour
@@ -34,7 +33,7 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
             throws MavenInvocationException, FileNotFoundException {
         run(performCompile, options);
 
-        String resp = DevModeTestUtils.getHttpResponse();
+        String resp = devModeClient.getHttpResponse();
 
         assertThat(resp).containsIgnoringCase("ready").containsIgnoringCase("application")
                 .containsIgnoringCase("1.0-SNAPSHOT");

--- a/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/quarkus-pact-provider/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.maven.it.RunAndCheckMojoTestBase;
 import io.quarkus.maven.it.continuoustesting.ContinuousTestingMavenTestUtils;
-import io.quarkus.test.devmode.util.DevModeTestUtils;
+import io.quarkus.test.devmode.util.DevModeClient;
 
 /**
  * Because Pact uses Kotlin under the covers, we see different behaviour
@@ -36,12 +36,12 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
             throws MavenInvocationException, FileNotFoundException {
         run(performCompile, options);
 
-        String resp = DevModeTestUtils.getHttpResponse();
+        String resp = devModeClient.getHttpResponse();
 
         assertThat(resp).containsIgnoringCase("ready").containsIgnoringCase("application")
                 .containsIgnoringCase("1.0-SNAPSHOT");
 
-        String json = DevModeTestUtils.getHttpResponse("/alpaca");
+        String json = devModeClient.getHttpResponse("/alpaca");
         //Minimal sense check, the tests do the heavy validation
         assertThat(json).containsIgnoringCase("colour");
     }
@@ -55,7 +55,7 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
         await()
                 .pollDelay(100, TimeUnit.MILLISECONDS)
                 .atMost(5, TimeUnit.SECONDS)
-                .until(() -> DevModeTestUtils.getHttpResponse("/alpaca").startsWith("{"));
+                .until(() -> new DevModeClient().getHttpResponse("/alpaca").startsWith("{"));
 
         ContinuousTestingMavenTestUtils testingTestUtils = new ContinuousTestingMavenTestUtils();
         ContinuousTestingMavenTestUtils.TestStatus results = testingTestUtils.waitForNextCompletion();


### PR DESCRIPTION
`DevModeTestUtils` should be replaced with an instance of `DevModeClient`. The parent classes have an instance we can use.