### PR TITLE
Minor bump in Pact version

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
 :project-version: 1.1.0
-:pact-version: 4.5.6
+:pact-version: 4.5.7
 
 :examples-dir: ./../examples/

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </scm>
   <properties>
     <quarkus.version>3.7.0</quarkus.version>
-    <pact.version>4.5.6</pact.version>
+    <pact.version>4.5.7</pact.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
It's not possible to go up to 4.5.8 (or higher) without resolving the following issues, but now that the build is running with Java 17, 4.5.7 is a clean transition. 

```
Caused by: java.lang.NoClassDefFoundError: org/apache/commons/io/input/UnsynchronizedByteArrayInputStream
        at au.com.dius.pact.core.model.ContentType.<clinit>(ContentType.kt:152)
        at au.com.dius.pact.core.model.Request$Companion.fromJson(Request.kt:160)
        at au.com.dius.pact.core.model.DefaultPactReader.extractRequest(PactReader.kt:327)
        at au.com.dius.pact.core.model.DefaultPactReader$loadV2Pact$interactions$1.invoke(PactReader.kt:283)
        at au.com.dius.pact.core.model.DefaultPactReader$loadV2Pact$interactions$1.invoke(PactReader.kt:282)
        at au.com.dius.pact.core.support.json.JsonValueKt.map(JsonValue.kt:335)
        at au.com.dius.pact.core.model.DefaultPactReader.loadV2Pact(PactReader.kt:282)
        at au.com.dius.pact.core.model.DefaultPactReader.pactFromJson(PactReader.kt:220)
        at au.com.dius.pact.core.model.DefaultPactReader.loadPact(PactReader.kt:211)
        at au.com.dius.pact.core.model.DefaultPactReader.loadPact(PactReader.kt:207)
        at au.com.dius.pact.provider.junitsupport.loader.PactFolderLoader.load(PactFolderLoader.kt:54)
        at au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider$resolvePactSources$pactSources$1$pacts$1.invoke(PactJUnit5VerificationProvider.kt:78)
        at au.com.dius.pact.core.support.KotlinLanguageSupportKt.handleWith(KotlinLanguageSupport.kt:35)
```

and also 

```
 java.lang.NoClassDefFoundError: io/github/oshai/kotlinlogging/KLogging
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1027)
        at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:508)
        at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:468)
        at au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider.<clinit>(PactJUnit5VerificationProvider.kt)
```