### PR TITLE
Fix failures in ecosystem CI, caused by insufficient memory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,4 @@ updates:
     schedule:
       interval: daily
     labels:
-      - area/infra
+      - infra

--- a/cross-extension-integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/cross-extension-integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -73,7 +73,7 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
         //running at once, if they add default to 75% of total mem we can easily run out
         //of physical memory as they will consume way more than what they need instead of
         //just running GC
-        args.add("-Djvm.args='-Xmx140m'");
+        args.add("-Djvm.args='-Xmx160m'");
         running.execute(args, Map.of());
     }
 


### PR DESCRIPTION
Somewhere between Quarkus 3.11 and 3.12 [the ecosystem CI started failing](https://github.com/quarkiverse/quarkiverse/issues/94). The root cause was not obvious, but I believe it is caused by OOMs somewhere, which do not make it to visible stack traces. 

The pragmatic fix for pact is to allow more memory. The Quarkus issue is (sort of) tracked by https://github.com/quarkusio/quarkus/issues/38814 and https://github.com/quarkusio/quarkus/issues/41156.