### PR TITLE
Enable test for injection

### DIFF
--- a/cross-extension-integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/cross-extension-integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -109,7 +109,7 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
 
         ContinuousTestingMavenTestUtils testingTestUtils = new ContinuousTestingMavenTestUtils();
         ContinuousTestingMavenTestUtils.TestStatus results = testingTestUtils.waitForNextCompletion();
-        Assertions.assertEquals(6, results.getTestsPassed());
+        Assertions.assertEquals(7, results.getTestsPassed());
         Assertions.assertEquals(0, results.getTestsFailed());
 
     }

--- a/cross-extension-integration-tests/src/test/java/io/quarkiverse/pact/it/TheTestModeContractTestIT.java
+++ b/cross-extension-integration-tests/src/test/java/io/quarkiverse/pact/it/TheTestModeContractTestIT.java
@@ -75,7 +75,7 @@ public class TheTestModeContractTestIT extends RunAndCheckMojoTestBase {
         TestModeContinuousTestingMavenTestUtils testingTestUtils = new TestModeContinuousTestingMavenTestUtils(running);
 
         ContinuousTestingMavenTestUtils.TestStatus results = testingTestUtils.waitForNextCompletion();
-        Assertions.assertEquals(6, results.getTestsPassed());
+        Assertions.assertEquals(7, results.getTestsPassed());
         Assertions.assertEquals(0, results.getTestsFailed());
 
     }

--- a/cross-extension-integration-tests/src/test/resources-filtered/projects/happy-everyone-all-together/src/test/java/io/quarkiverse/pact/devmodetest/consumer/knitter/FarmWithInjectionConsumerTest.java
+++ b/cross-extension-integration-tests/src/test/resources-filtered/projects/happy-everyone-all-together/src/test/java/io/quarkiverse/pact/devmodetest/consumer/knitter/FarmWithInjectionConsumerTest.java
@@ -6,8 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.HashMap;
 import java.util.Map;
 
+import jakarta.inject.Inject;
+
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -22,7 +23,6 @@ import io.quarkiverse.pact.consumer.testapp.ConsumerAlpaca;
 import io.quarkiverse.pact.consumer.testapp.Knitter;
 import io.quarkiverse.pact.consumer.testapp.SheepService;
 import io.quarkus.test.junit.QuarkusTest;
-import jakarta.inject.Inject;
 
 @ExtendWith(PactConsumerTestExt.class)
 @PactTestFor(providerName = "farm", port = "8085")
@@ -82,9 +82,7 @@ public class FarmWithInjectionConsumerTest {
     }
 
     @Test
-    @Disabled // With Quarkus 3, test methods cannot directly access Pact classes, because they are in different classloaders. See https://github.com/quarkiverse/quarkus-pact/issues/73
-    // The good news is there are very few use cases where test code should be doing parameter injection of the mock server.
-    public void testPortIsCorrect(MockServer mockServer) {
+    public void testInjectionOfMockServer(MockServer mockServer) {
         // If we have a test, pact assumes we will call it and validates there was a call
         ConsumerAlpaca alpaca = sheepService.getByName("fluffy");
         assertEquals(8085, mockServer.getPort()); // Testing the mock - don't do this normally!

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
 :project-version: 1.4.2
-:pact-version: 4.6.10
+:pact-version: 4.6.11
 
 :examples-dir: ./../examples/

--- a/quarkus-pact-consumer/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
+++ b/quarkus-pact-consumer/integration-tests/src/test/java/io/quarkiverse/pact/it/DevModeContractTestIT.java
@@ -52,7 +52,7 @@ public class DevModeContractTestIT extends RunAndCheckMojoTestBase {
         ContinuousTestingMavenTestUtils.TestStatus results = testingTestUtils.waitForNextCompletion();
         // This is a bit brittle when we add tests, but failures are often so catastrophic they're not even reported as failures,
         // so we need to check the pass count explicitly
-        Assertions.assertEquals(4, results.getTestsPassed());
+        Assertions.assertEquals(5, results.getTestsPassed());
         Assertions.assertEquals(0, results.getTestsFailed());
 
         // Now confirm a pact file got written by the pact consumer

--- a/quarkus-pact-consumer/integration-tests/src/test/java/io/quarkiverse/pact/it/TestModeContractTestIT.java
+++ b/quarkus-pact-consumer/integration-tests/src/test/java/io/quarkiverse/pact/it/TestModeContractTestIT.java
@@ -68,7 +68,7 @@ public class TestModeContractTestIT extends RunAndCheckMojoTestBase {
         ContinuousTestingMavenTestUtils.TestStatus results = testingTestUtils.waitForNextCompletion();
         // This is a bit brittle when we add tests, but failures are often so catastrophic they're not even reported as failures,
         // so we need to check the pass count explicitly
-        Assertions.assertEquals(4, results.getTestsPassed());
+        Assertions.assertEquals(5, results.getTestsPassed());
         Assertions.assertEquals(0, results.getTestsFailed());
 
         // Now confirm a pact file got written by the pact consumer

--- a/quarkus-pact-consumer/integration-tests/src/test/resources-filtered/projects/happy-knitter/src/test/java/io/quarkiverse/pact/devmodetest/farm/FarmWithInjectionConsumerTest.java
+++ b/quarkus-pact-consumer/integration-tests/src/test/resources-filtered/projects/happy-knitter/src/test/java/io/quarkiverse/pact/devmodetest/farm/FarmWithInjectionConsumerTest.java
@@ -6,8 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.HashMap;
 import java.util.Map;
 
+import jakarta.inject.Inject;
+
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -22,7 +23,6 @@ import io.quarkiverse.pact.testapp.AlpacaService;
 import io.quarkiverse.pact.testapp.ConsumerAlpaca;
 import io.quarkiverse.pact.testapp.Knitter;
 import io.quarkus.test.junit.QuarkusTest;
-import jakarta.inject.Inject;
 
 @ExtendWith(PactConsumerTestExt.class)
 @PactTestFor(providerName = "farm", port = "8085")
@@ -82,9 +82,7 @@ public class FarmWithInjectionConsumerTest {
     }
 
     @Test
-    @Disabled // With Quarkus 3, test methods cannot directly access Pact classes, because they are in different classloaders. See https://github.com/quarkiverse/quarkus-pact/issues/73
-    // The good news is there are very few use cases where test code should be doing parameter injection of the mock server.
-    public void testPortIsCorrect(MockServer mockServer) {
+    public void testInjectionOfMockServer(MockServer mockServer) {
         // If we have a test, pact assumes we will call it and validates there was a call
         ConsumerAlpaca alpaca = alpacaService.getByName("fluffy");
         assertEquals(8085, mockServer.getPort()); // Testing the mock - don't do this normally!


### PR DESCRIPTION
Fixes #73, by confirming that parameter injection now works properly with Quarkus 3.13.0.